### PR TITLE
Ignore prettier warning in licensed.yml

### DIFF
--- a/.github/workflows/licensed.yml
+++ b/.github/workflows/licensed.yml
@@ -77,6 +77,7 @@ jobs:
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
           fi
 
+      # prettier-ignore
       - if: ${{ github.event_name == 'workflow_dispatch' && steps.commit-licenses.outputs.has_changes == 'true' }}
         name: Create Pull Request
         id: create-pr


### PR DESCRIPTION
Add a `prettier-ignore` comment to suppress formatting warnings in the `licensed.yml` file. This change ensures that the workflow remains unaffected by prettier's formatting rules.